### PR TITLE
adds timeout_duration

### DIFF
--- a/regimen.yml
+++ b/regimen.yml
@@ -68,6 +68,7 @@ _flash_parameters: &flash_parameters
 
     # trial timing
     min_no_lick_time: 0.3
+    timeout_duration: 0.3
     pre_change_time: 2.25
     stimulus_window: 6.0
     max_task_duration_min: 60.0
@@ -100,7 +101,7 @@ _image_set_c_parameters: &image_set_c_parameters
 
 ### mtrain definitions
 
-name: VisualBehavior_Task1A_v0.2.2
+name: VisualBehavior_Task1A_v0.2.3
 
 transitions:
 


### PR DESCRIPTION
this is a patch to add a missing parameter to the regimen. mice can be migrated directly to this from VisualBehavior_Task1A_v0.2.2

cc @derricw @dougollerenshaw @nicain 