### PR TITLE
updated associative learning stim params

### DIFF
--- a/regimen.yml
+++ b/regimen.yml
@@ -18,7 +18,7 @@ _parameters: &parameters
   dev: false
   monitor: "Gamma1.Luminance50"
   auto_reward_delay: 0.6
-  auto_reward_vol: 0.007
+  auto_reward_vol: 0.005
   catch_frequency: null
   change_flashes_max: 12
   change_flashes_min: 4
@@ -27,15 +27,15 @@ _parameters: &parameters
   end_after_response: true
   end_after_response_sec: 0.0
   failure_repeats: 5
-  flash_omit_probability: 1.0
+  flash_omit_probability: 0.05
   free_reward_trials: 1
   max_task_duration_min: 60.0
   max_trials: 2000
   min_no_lick_time: 0.0
-  periodic_flash: [0.25, 0.5]
+  periodic_flash: [0.25, 0.75]
   pre_change_time: 0.0
-  response_window: [0.15, 0.75]
-  reward_volume: 0.007
+  response_window: [0.15, 1.0]
+  reward_volume: 0.005
   start_stop_padding: 5.0
   stimulus_window": 6.0
   task_id: DoC
@@ -49,7 +49,7 @@ _parameters: &parameters
   consumption_window: null
 
 ### mtrain definitions
-name: AssociativeLearning_v0.0.4
+name: AssociativeLearning_v0.0.5
 
 transitions:
   # in case a transition is required by mtrain


### PR DESCRIPTION
just changed some of the param values for next version of associative learning task. lengthen stim flash offset, lower reward volume, increased response window

@corbennett or @mochic 